### PR TITLE
let them bookmark and we keep app state at initial load by passing url to $routeProvider

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,12 @@ app.use(express.methodOverride());
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(app.router);
 
+// middleware function puts hash before req.params
+// redirect logic falls back to angular $routeProvider
+app.use(function(req, res) {
+	return res.redirect(req.protocol + '://' + req.get('Host') + '/#' + req.url)
+});
+
 // development only
 if (app.get('env') === 'development') {
   app.use(express.errorHandler());
@@ -47,9 +53,6 @@ app.get('/partials/:name', routes.partials);
 
 // JSON API
 app.get('/api/name', api.name);
-
-// redirect all others to the index (HTML5 history)
-app.get('*', routes.index);
 
 
 /**


### PR DESCRIPTION
when set up express for our SPAs, I think we should probably avoid unix style \* redirect logic for all routes inside the express app.router and instead favor client config like $routeProvider
