### PR TITLE
Update app.js - allow refresh

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies
  */
@@ -43,6 +42,7 @@ if (app.get('env') === 'production') {
 
 // serve index and view partials
 app.get('/', routes.index);
+app.get('/:name', routes.index);
 app.get('/partials/:name', routes.partials);
 
 // JSON API


### PR DESCRIPTION
Problem: 
When refreshing the page at a URL such as http://localhost:3000/view2 the Seed App fails, as Express has no route for /view2

Solution:
Provide an index catch-all to render index, and allow Angular to handle the route to /view2
