### PR TITLE
Update middleware "errorhandler" to the Express 4.x new style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@
 var express = require('express'),
   bodyParser = require('body-parser'),
   methodOverride = require('method-override'),
-  errorHandler = require('error-handler'),
+  errorhandler = require('errorhandler'),
   morgan = require('morgan'),
   routes = require('./routes'),
   api = require('./routes/api'),
@@ -33,7 +33,7 @@ var env = process.env.NODE_ENV || 'development';
 
 // development only
 if (env === 'development') {
-  app.use(express.errorHandler());
+  app.use(errorhandler());
 }
 
 // production only

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "body-parser": "^1.0.2",
-    "error-handler": "^0.1.4",
+    "errorhandler": "^1.0.1",
     "express": "~4.1.1",
     "jade": "~0.31.2",
     "method-override": "^1.0.0",


### PR DESCRIPTION
Replace the old middleware "error-handler" by the new one "errorhandler"
Now the command line `node app.js` just work like a charm !

I also add a simple .gitignore file to exclude "node_modules" folder : I guess is best for a seed Node.js project
