### PR TITLE
Use express-error-handler instead of error-handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@
 var express = require('express'),
   bodyParser = require('body-parser'),
   methodOverride = require('method-override'),
-  errorHandler = require('error-handler'),
+  errorHandler = require('express-error-handler'),
   morgan = require('morgan'),
   routes = require('./routes'),
   api = require('./routes/api'),
@@ -33,7 +33,7 @@ var env = process.env.NODE_ENV || 'development';
 
 // development only
 if (env === 'development') {
-  app.use(express.errorHandler());
+  app.use(errorHandler());
 }
 
 // production only

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "body-parser": "^1.0.2",
-    "error-handler": "^0.1.4",
+    "express-error-handler": "^0.5.4",
     "express": "~4.1.1",
     "jade": "~0.31.2",
     "method-override": "^1.0.0",


### PR DESCRIPTION
Hi,

I think you need express-error-handler instead of error-handler, otherwise it doesn't work.

Also, the app.use has to point to the external module, not the one in Express.

I've run the project after these changes, and it seems to work properly.  With just error-handler, it would hang instead of replying to requests.
