### PR TITLE
this repo can't run in Express 4

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@
 var express = require('express'),
   bodyParser = require('body-parser'),
   methodOverride = require('method-override'),
-  errorHandler = require('error-handler'),
+  errorHandler = require('errorhandler'),
   morgan = require('morgan'),
   routes = require('./routes'),
   api = require('./routes/api'),
@@ -25,7 +25,10 @@ app.set('port', process.env.PORT || 3000);
 app.set('views', __dirname + '/views');
 app.set('view engine', 'jade');
 app.use(morgan('dev'));
-app.use(bodyParser());
+app.use(bodyParser.urlencoded({
+  extended: true
+}));
+app.use(bodyParser.json());
 app.use(methodOverride());
 app.use(express.static(path.join(__dirname, 'public')));
 
@@ -33,7 +36,7 @@ var env = process.env.NODE_ENV || 'development';
 
 // development only
 if (env === 'development') {
-  app.use(express.errorHandler());
+  app.use(errorHandler());
 }
 
 // production only

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "body-parser": "^1.0.2",
     "error-handler": "^0.1.4",
+    "errorhandler": "^1.4.3",
     "express": "~4.1.1",
     "jade": "~0.31.2",
     "method-override": "^1.0.0",


### PR DESCRIPTION
Hey.

I clone this repo to my computer, but it can't run, and I found errors below. So, I change something to fix these. Please check it.

/home/henry/Documents/angular-express-seed/node_modules/express/lib/express.js:89
      throw new Error('Most middleware (like ' + name + ') is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.');
      ^

Error: Most middleware (like errorHandler) is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.
    at Function.Object.defineProperty.get (/home/henry/Documents/angular-express-seed/node_modules/express/lib/express.js:89:13)
    at Object.<anonymous> (/home/henry/Documents/angular-express-seed/app.js:36:18)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
    at Function.Module._load (module.js:407:3)
    at Function.Module.runMain (module.js:575:10)
    at startup (node.js:159:18)
    at node.js:444:3

/home/henry/Documents/angular-express-seed/node_modules/express/lib/express.js:89
      throw new Error('Most middleware (like ' + name + ') is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.');
      ^

Error: Most middleware (like errorHandler) is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.
    at Function.Object.defineProperty.get (/home/henry/Documents/angular-express-seed/node_modules/express/lib/express.js:89:13)
    at Object.<anonymous> (/home/henry/Documents/angular-express-seed/app.js:39:18)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
    at Function.Module._load (module.js:407:3)
    at Function.Module.runMain (module.js:575:10)
    at startup (node.js:159:18)
    at node.js:444:3
